### PR TITLE
Move API routes under /api prefix

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -62,19 +62,19 @@
         },
         methods: {
             async loadProjects() {
-                const res = await fetch('/projects');
+                const res = await fetch('/api/projects');
                 const data = await res.json();
                 this.projects = data.projects;
                 this.activeProject = data.active || '';
             },
             async addProject() {
                 if(!this.newProject) return;
-                await fetch('/projects', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name:this.newProject})});
+                await fetch('/api/projects', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name:this.newProject})});
                 this.newProject='';
                 this.loadProjects();
             },
             async switchProject(name) {
-                await fetch('/projects/switch', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name})});
+                await fetch('/api/projects/switch', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name})});
                 this.activeProject = name;
                 this.messages = [];
             },
@@ -84,7 +84,7 @@
                 const currentPrompt = this.prompt;
                 this.prompt='';
                 this.loading = true;
-                const res = await fetch('/chat', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({prompt:currentPrompt})});
+                const res = await fetch('/api/chat', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({prompt:currentPrompt})});
                 const data = await res.json();
                 this.messages.push({id:Date.now()+1, role:'assistant', content:data.response});
                 this.loading=false;

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -26,11 +26,13 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the Codex web server",
 	Run: func(cmd *cobra.Command, args []string) {
-		http.HandleFunc("/chat", handlers2.ChatHandler)
-		http.HandleFunc("/projects", handlers2.ProjectsHandler)
-		http.HandleFunc("/projects/switch", handlers2.SwitchProjectHandler)
-		http.HandleFunc("/projects/rename", handlers2.RenameProjectHandler)
-		http.HandleFunc("/projects/", handlers2.DeleteProjectHandler)
+		// All API endpoints are now grouped under the /api prefix so the
+		// root path only serves the client UI.
+		http.HandleFunc("/api/chat", handlers2.ChatHandler)
+		http.HandleFunc("/api/projects", handlers2.ProjectsHandler)
+		http.HandleFunc("/api/projects/switch", handlers2.SwitchProjectHandler)
+		http.HandleFunc("/api/projects/rename", handlers2.RenameProjectHandler)
+		http.HandleFunc("/api/projects/", handlers2.DeleteProjectHandler)
 
 		// Serve index.html at "/" only
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/src/handlers/chat_test.go
+++ b/src/handlers/chat_test.go
@@ -42,7 +42,7 @@ func TestChatHandlerSuccess(t *testing.T) {
 	}
 
 	body := bytes.NewBufferString(`{"prompt":"hi"}`)
-	req := httptest.NewRequest(http.MethodPost, "/chat", body)
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", body)
 	w := httptest.NewRecorder()
 	ChatHandler(w, req)
 	res := w.Result()
@@ -61,7 +61,7 @@ func TestChatHandlerSuccess(t *testing.T) {
 // TestChatHandlerMethod confirms that ChatHandler rejects non-POST requests
 // with a method-not-allowed status.
 func TestChatHandlerMethod(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/chat", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/chat", nil)
 	w := httptest.NewRecorder()
 	ChatHandler(w, req)
 	if w.Result().StatusCode != http.StatusMethodNotAllowed {

--- a/src/handlers/project.go
+++ b/src/handlers/project.go
@@ -13,7 +13,7 @@ import (
 // This file implements HTTP handlers for managing assistant projects. Projects
 // allow the AI to maintain multiple independent memory banks.
 
-// ProjectsResponse is returned by GET /projects
+// ProjectsResponse is returned by GET /api/projects
 type ProjectsResponse struct {
 	// Projects contains the list of all known project names.
 	Projects []string `json:"projects"`
@@ -22,7 +22,7 @@ type ProjectsResponse struct {
 }
 
 // ProjectsHandler handles listing and creating projects. It responds to both
-// GET and POST on the /projects endpoint and interacts with the memory package
+// GET and POST on the /api/projects endpoint and interacts with the memory package
 // for persistence. Extension Point: additional methods such as PUT could be
 // added here to extend project metadata management.
 func ProjectsHandler(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +64,7 @@ func ProjectsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // SwitchProjectHandler sets the active project. Clients post a project name to
-// /projects/switch to change context for subsequent chat operations. AI
+// /api/projects/switch to change context for subsequent chat operations. AI
 // Awareness: by switching project, the assistant focuses memory queries on a
 // different conversation context.
 func SwitchProjectHandler(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func SwitchProjectHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// DeleteProjectHandler removes a project identified by /projects/{name}. It
+// DeleteProjectHandler removes a project identified by /api/projects/{name}. It
 // will also unset the active project if that project is being deleted. This is
 // primarily used by the CLI and HTTP API when the user wants to discard a
 // conversation history.
@@ -102,8 +102,9 @@ func DeleteProjectHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	// Extract the project name from the URL path.
-	name := strings.TrimPrefix(r.URL.Path, "/projects/")
+	// Extract the project name from the URL path. Requests are routed with
+	// the /api prefix so we strip that as well.
+	name := strings.TrimPrefix(r.URL.Path, "/api/projects/")
 	if name == "" {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/src/handlers/project_test.go
+++ b/src/handlers/project_test.go
@@ -31,7 +31,7 @@ func TestProjectAPI(t *testing.T) {
 
 	// create project p1
 	body := bytes.NewBufferString(`{"name":"p1"}`)
-	req := httptest.NewRequest(http.MethodPost, "/projects", body)
+	req := httptest.NewRequest(http.MethodPost, "/api/projects", body)
 	w := httptest.NewRecorder()
 	ProjectsHandler(w, req)
 	if w.Result().StatusCode != http.StatusCreated {
@@ -40,7 +40,7 @@ func TestProjectAPI(t *testing.T) {
 
 	// switch to p1
 	body = bytes.NewBufferString(`{"name":"p1"}`)
-	req = httptest.NewRequest(http.MethodPost, "/projects/switch", body)
+	req = httptest.NewRequest(http.MethodPost, "/api/projects/switch", body)
 	w = httptest.NewRecorder()
 	SwitchProjectHandler(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -48,7 +48,7 @@ func TestProjectAPI(t *testing.T) {
 	}
 
 	// list
-	req = httptest.NewRequest(http.MethodGet, "/projects", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/projects", nil)
 	w = httptest.NewRecorder()
 	ProjectsHandler(w, req)
 	var resp ProjectsResponse
@@ -61,7 +61,7 @@ func TestProjectAPI(t *testing.T) {
 
 	// rename project p1 to p2
 	body = bytes.NewBufferString(`{"old":"p1","new":"p2"}`)
-	req = httptest.NewRequest(http.MethodPost, "/projects/rename", body)
+	req = httptest.NewRequest(http.MethodPost, "/api/projects/rename", body)
 	w = httptest.NewRecorder()
 	RenameProjectHandler(w, req)
 	if w.Result().StatusCode != http.StatusOK {
@@ -69,7 +69,7 @@ func TestProjectAPI(t *testing.T) {
 	}
 
 	// verify rename
-	req = httptest.NewRequest(http.MethodGet, "/projects", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/projects", nil)
 	w = httptest.NewRecorder()
 	ProjectsHandler(w, req)
 	if err := json.NewDecoder(w.Result().Body).Decode(&resp); err != nil {
@@ -80,7 +80,7 @@ func TestProjectAPI(t *testing.T) {
 	}
 
 	// delete
-	req = httptest.NewRequest(http.MethodDelete, "/projects/p1", nil)
+	req = httptest.NewRequest(http.MethodDelete, "/api/projects/p1", nil)
 	w = httptest.NewRecorder()
 	DeleteProjectHandler(w, req)
 	if w.Result().StatusCode != http.StatusOK {


### PR DESCRIPTION
## Summary
- scope all HTTP API endpoints under `/api`
- update DeleteProjectHandler for new prefix
- adjust client requests
- update tests for new routes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68703baed3f0832287664cf0532474e7