### PR TITLE
Add user creation CLI and registration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ server and stores conversation history in a local SQLite database.
 - **Lightweight web client** under the `client/` directory
 - **User accounts with optional 2FA** for login/logout
 - **Simple admin area** served from the web client
+- **Self-service registration** from the login popup
 
 ## Building
 
@@ -54,6 +55,7 @@ docker-compose up
 - `codex models download [id]` – download model files
 - `codex models use [id]` – mark a downloaded model as active
 - `codex models status` – show the currently active model
+- `codex user create [username] [email] [password]` – create a user account
 
 Run `codex [command] --help` for detailed flags.
 

--- a/src/client/src/components/Login.vue
+++ b/src/client/src/components/Login.vue
@@ -1,30 +1,87 @@
 <template>
-  <form @submit.prevent="login" class="space-y-2 max-w-sm mx-auto mt-20">
-    <input v-model="username" placeholder="Username" class="w-full p-2 border" />
-    <input v-model="password" type="password" placeholder="Password" class="w-full p-2 border" />
-    <input v-if="totp" v-model="code" placeholder="TOTP" class="w-full p-2 border" />
-    <button class="px-4 py-2 bg-blue-600 text-white">Login</button>
+  <form @submit.prevent="submit" class="space-y-2 max-w-sm mx-auto mt-20">
+    <input
+      v-model="username"
+      placeholder="Username"
+      class="w-full p-2 border"
+    />
+    <input
+      v-if="mode === 'register'"
+      v-model="email"
+      placeholder="Email"
+      class="w-full p-2 border"
+    />
+    <input
+      v-model="password"
+      type="password"
+      placeholder="Password"
+      class="w-full p-2 border"
+    />
+    <input
+      v-if="totp"
+      v-model="code"
+      placeholder="TOTP"
+      class="w-full p-2 border"
+    />
+    <button class="px-4 py-2 bg-blue-600 text-white">
+      {{ mode === "register" ? "Register" : "Login" }}
+    </button>
+    <p class="text-sm text-center">
+      <a href="#" @click.prevent="toggle">{{
+        mode === "register"
+          ? "Already have an account? Login"
+          : "Need an account? Register"
+      }}</a>
+    </p>
   </form>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-const username = ref('')
-const password = ref('')
-const code = ref('')
-const totp = ref(false)
+import { ref } from "vue";
+const username = ref("");
+const email = ref("");
+const password = ref("");
+const code = ref("");
+const totp = ref(false);
+const mode = ref<"login" | "register">("login");
 
-async function login() {
-  const res = await fetch('/api/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ Username: username.value, Password: password.value, TOTP: code.value })
-  })
-  if (res.status === 401) {
-    alert('login failed')
-  } else if (res.ok) {
-    window.location.reload()
+async function submit() {
+  if (mode.value === "login") {
+    const res = await fetch("/api/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        Username: username.value,
+        Password: password.value,
+        TOTP: code.value,
+      }),
+    });
+    if (res.status === 401) {
+      alert("login failed");
+    } else if (res.ok) {
+      window.location.reload();
+    }
+  } else {
+    const res = await fetch("/api/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        Username: username.value,
+        Email: email.value,
+        Password: password.value,
+      }),
+    });
+    if (!res.ok) {
+      alert("register failed");
+    } else {
+      alert("registered, awaiting verification");
+      mode.value = "login";
+    }
   }
+}
+
+function toggle() {
+  mode.value = mode.value === "login" ? "register" : "login";
 }
 </script>
 

--- a/src/cmd/cmd_test.go
+++ b/src/cmd/cmd_test.go
@@ -5,6 +5,7 @@ package cmd
 // common error scenarios.
 
 import (
+	"codex/src/auth"
 	"codex/src/memory"
 	"os"
 	"testing"
@@ -43,5 +44,25 @@ func TestExecuteInvalidCommand(t *testing.T) {
 	rootCmd.SetArgs([]string{"nonexist"})
 	if err := Execute(); err == nil {
 		t.Fatalf("expected error for invalid command")
+	}
+}
+func TestCreateUserCommand(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+
+	if err := createUserCmd.RunE(createUserCmd, []string{"bob", "b@c.com", "pwd"}); err != nil {
+		t.Fatalf("command error: %v", err)
+	}
+
+	db, err := memory.InitDB()
+	if err != nil {
+		t.Fatalf("InitDB error: %v", err)
+	}
+	defer db.Close()
+	u, err := auth.GetByUsername(db, "bob")
+	if err != nil || u == nil {
+		t.Fatalf("user not created: %v", err)
 	}
 }

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -1,0 +1,40 @@
+package cmd
+
+// This file defines CLI commands for managing user accounts. Currently it
+// exposes a `create` subcommand allowing an administrator to create a new
+// account directly from the terminal.
+
+import (
+	"codex/src/auth"
+	"codex/src/memory"
+	"github.com/spf13/cobra"
+)
+
+// usersCmd is the parent for user related subcommands.
+var usersCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Manage users",
+}
+
+// createUserCmd creates a user in the local database.
+var createUserCmd = &cobra.Command{
+	Use:   "create [username] [email] [password]",
+	Short: "Create a new user",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		username := args[0]
+		email := args[1]
+		password := args[2]
+		db, err := memory.InitDB()
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return auth.CreateUser(db, username, email, password)
+	},
+}
+
+func init() {
+	usersCmd.AddCommand(createUserCmd)
+	rootCmd.AddCommand(usersCmd)
+}


### PR DESCRIPTION
## Summary
- allow registration directly from login component
- document registration feature and new CLI command
- implement `user create` subcommand
- add tests for new CLI command

## Testing
- `go test ./...`
- `npx prettier -w src/client/src/components/Login.vue`

------
https://chatgpt.com/codex/tasks/task_e_6871023b44a48322bbc2511bc7f2422e