### PR TITLE
Add admin promotion CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ docker-compose up
 - `codex models use [id]` – mark a downloaded model as active
 - `codex models status` – show the currently active model
 - `codex user create [username] [email] [password]` – create a user account
+- `codex user promote [username]` – grant admin rights to a user
 
 Run `codex [command] --help` for detailed flags.
 

--- a/src/client/src/App.vue
+++ b/src/client/src/App.vue
@@ -48,7 +48,6 @@ function parseSession() {
   if (match) {
     loggedIn.value = true
     userId.value = parseInt(match[1])
-    isAdmin.value = userId.value === 1
   }
 }
 
@@ -59,7 +58,10 @@ async function fetchUsername() {
     if (res.ok) {
       const users = await res.json()
       const u = users.find((u: any) => u.id === userId.value)
-      if (u) username.value = u.username
+      if (u) {
+        username.value = u.username
+        isAdmin.value = u.admin === true || u.admin === 1
+      }
     }
   } catch {}
 }

--- a/src/cmd/cmd_test.go
+++ b/src/cmd/cmd_test.go
@@ -66,3 +66,29 @@ func TestCreateUserCommand(t *testing.T) {
 		t.Fatalf("user not created: %v", err)
 	}
 }
+
+func TestPromoteUserCommand(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+
+	// create user first
+	if err := createUserCmd.RunE(createUserCmd, []string{"eve", "e@c.com", "pwd"}); err != nil {
+		t.Fatalf("create error: %v", err)
+	}
+	// promote
+	if err := promoteUserCmd.RunE(promoteUserCmd, []string{"eve"}); err != nil {
+		t.Fatalf("promote error: %v", err)
+	}
+
+	db, err := memory.InitDB()
+	if err != nil {
+		t.Fatalf("InitDB error: %v", err)
+	}
+	defer db.Close()
+	u, err := auth.GetByUsername(db, "eve")
+	if err != nil || !u.Admin {
+		t.Fatalf("user not promoted: %+v err:%v", u, err)
+	}
+}

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -34,7 +34,24 @@ var createUserCmd = &cobra.Command{
 	},
 }
 
+// promoteUserCmd marks an existing user as an admin.
+var promoteUserCmd = &cobra.Command{
+	Use:   "promote [username]",
+	Short: "Promote a user to admin",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		username := args[0]
+		db, err := memory.InitDB()
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		return auth.SetAdmin(db, username, true)
+	},
+}
+
 func init() {
 	usersCmd.AddCommand(createUserCmd)
+	usersCmd.AddCommand(promoteUserCmd)
 	rootCmd.AddCommand(usersCmd)
 }

--- a/src/memory/memory.go
+++ b/src/memory/memory.go
@@ -59,11 +59,14 @@ func InitDB() (*sql.DB, error) {
                email TEXT UNIQUE,
                password TEXT,
                verified INTEGER DEFAULT 0,
-               totp_secret TEXT
+               totp_secret TEXT,
+               admin INTEGER DEFAULT 0
        );`); err != nil {
 		db.Close()
 		return nil, err
 	}
+	// attempt to add admin column if the table already existed without it
+	db.Exec(`ALTER TABLE users ADD COLUMN admin INTEGER DEFAULT 0`)
 	return db, nil
 }
 


### PR DESCRIPTION
## Summary
- support `user promote` CLI command
- store admin state in database
- expose admin info in API and client
- document promote command
- test user promotion

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68710b90cd1883228396826a056fb3f7