### PR TITLE
Add list users CLI command

### DIFF
--- a/src/cmd/cmd_test.go
+++ b/src/cmd/cmd_test.go
@@ -92,3 +92,32 @@ func TestPromoteUserCommand(t *testing.T) {
 		t.Fatalf("user not promoted: %+v err:%v", u, err)
 	}
 }
+
+func TestListUsersCommand(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	os.Chdir(dir)
+
+	// create a couple users
+	if err := createUserCmd.RunE(createUserCmd, []string{"john", "j@c.com", "pwd"}); err != nil {
+		t.Fatalf("create error: %v", err)
+	}
+	if err := createUserCmd.RunE(createUserCmd, []string{"kate", "k@c.com", "pwd"}); err != nil {
+		t.Fatalf("create error: %v", err)
+	}
+
+	if err := listUsersCmd.RunE(listUsersCmd, []string{}); err != nil {
+		t.Fatalf("list error: %v", err)
+	}
+
+	db, err := memory.InitDB()
+	if err != nil {
+		t.Fatalf("InitDB error: %v", err)
+	}
+	defer db.Close()
+	users, err := auth.List(db)
+	if err != nil || len(users) != 2 {
+		t.Fatalf("unexpected list: %+v err:%v", users, err)
+	}
+}

--- a/src/cmd/user.go
+++ b/src/cmd/user.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"codex/src/auth"
 	"codex/src/memory"
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -50,8 +51,30 @@ var promoteUserCmd = &cobra.Command{
 	},
 }
 
+// listUsersCmd prints all registered users.
+var listUsersCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List users",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		db, err := memory.InitDB()
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		list, err := auth.List(db)
+		if err != nil {
+			return err
+		}
+		for _, u := range list {
+			fmt.Printf("%s\t%s\tadmin:%v verified:%v\n", u.Username, u.Email, u.Admin, u.Verified)
+		}
+		return nil
+	},
+}
+
 func init() {
 	usersCmd.AddCommand(createUserCmd)
 	usersCmd.AddCommand(promoteUserCmd)
+	usersCmd.AddCommand(listUsersCmd)
 	rootCmd.AddCommand(usersCmd)
 }


### PR DESCRIPTION
## Summary
- list users from CLI
- test for the new `user list` command

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871147d0ac48322b8e068ad5dcd9726