### PR TITLE
Improve login modal styling and validation

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,16 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LocalAI UI</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <style>
-      html, body, #app { height: 100%; }
-    </style>
   </head>
-  <body>
+  <body class="h-full bg-gray-900 text-gray-200">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/client/src/App.vue
+++ b/src/client/src/App.vue
@@ -20,17 +20,29 @@
     <ChatLayout v-if="view==='chat'" :logged-in="loggedIn" class="flex-1" />
     <AdminLayout v-else class="flex-1" />
 
-    <div v-if="showLogin" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-      <div class="bg-white p-4 rounded">
-        <Login />
-        <button class="mt-2 text-sm" @click="showLogin=false">Cancel</button>
+    <div
+      v-if="showLogin"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      @click.self="closeLogin"
+    >
+      <div class="relative bg-gray-800 text-gray-200 p-6 rounded-lg shadow-lg w-full max-w-md" aria-labelledby="auth-title">
+        <button
+          class="absolute top-2 right-2 text-gray-400 hover:text-white"
+          @click="closeLogin"
+          aria-label="Close login modal"
+        >
+          &times;
+        </button>
+        <Login @success="closeLogin" />
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import ChatLayout from './components/ChatLayout.vue'
 import Login from './components/Login.vue'
 import AdminLayout from './components/AdminLayout.vue'
@@ -42,6 +54,24 @@ const showLogin = ref(false)
 const username = ref('')
 const userId = ref<number | null>(null)
 const isAdmin = ref(false)
+
+function closeLogin() {
+  showLogin.value = false
+}
+
+function handleKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    closeLogin()
+  }
+}
+
+watch(showLogin, (val) => {
+  if (val) {
+    window.addEventListener('keydown', handleKey)
+  } else {
+    window.removeEventListener('keydown', handleKey)
+  }
+})
 
 function parseSession() {
   const match = document.cookie.match(/session=(\d+)/)

--- a/src/client/src/components/Login.vue
+++ b/src/client/src/components/Login.vue
@@ -1,36 +1,71 @@
 <template>
-  <form @submit.prevent="submit" class="space-y-2 max-w-sm mx-auto mt-20">
-    <input
-      v-model="username"
-      placeholder="Username"
-      class="w-full p-2 border"
-    />
-    <input
-      v-if="mode === 'register'"
-      v-model="email"
-      placeholder="Email"
-      class="w-full p-2 border"
-    />
-    <input
-      v-model="password"
-      type="password"
-      placeholder="Password"
-      class="w-full p-2 border"
-    />
-    <input
-      v-if="totp"
-      v-model="code"
-      placeholder="TOTP"
-      class="w-full p-2 border"
-    />
-    <button class="px-4 py-2 bg-blue-600 text-white">
-      {{ mode === "register" ? "Register" : "Login" }}
+  <form
+    @submit.prevent="submit"
+    class="space-y-4 max-w-md mx-auto"
+    novalidate
+  >
+    <h2 id="auth-title" class="text-xl font-semibold text-center">
+      {{ mode === 'register' ? 'Register' : 'Login' }}
+    </h2>
+    <div>
+      <label for="username" class="sr-only">Username</label>
+      <input
+        id="username"
+        v-model="username"
+        placeholder="Username"
+        class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200"
+        required
+        autocomplete="username"
+      />
+    </div>
+    <div v-if="mode === 'register'">
+      <label for="email" class="sr-only">Email</label>
+      <input
+        id="email"
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200"
+        required
+        autocomplete="email"
+      />
+    </div>
+    <div>
+      <label for="password" class="sr-only">Password</label>
+      <input
+        id="password"
+        v-model="password"
+        type="password"
+        placeholder="Password"
+        class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200"
+        required
+        autocomplete="current-password"
+      />
+    </div>
+    <div v-if="totp">
+      <label for="totp" class="sr-only">TOTP</label>
+      <input
+        id="totp"
+        v-model="code"
+        placeholder="TOTP"
+        class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200"
+      />
+    </div>
+
+    <ul v-if="errors.length" class="text-red-400 text-sm">
+      <li v-for="(e, i) in errors" :key="i">{{ e }}</li>
+    </ul>
+
+    <button
+      class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-500 disabled:opacity-50"
+    >
+      {{ mode === 'register' ? 'Register' : 'Login' }}
     </button>
     <p class="text-sm text-center">
-      <a href="#" @click.prevent="toggle">{{
-        mode === "register"
-          ? "Already have an account? Login"
-          : "Need an account? Register"
+      <a href="#" @click.prevent="toggle" class="underline">{{
+        mode === 'register'
+          ? 'Already have an account? Login'
+          : 'Need an account? Register'
       }}</a>
     </p>
   </form>
@@ -44,12 +79,28 @@ const password = ref("");
 const code = ref("");
 const totp = ref(false);
 const mode = ref<"login" | "register">("login");
+const errors = ref<string[]>([]);
+const emit = defineEmits<{
+  (e: 'success'): void
+}>();
 
 async function submit() {
-  if (mode.value === "login") {
-    const res = await fetch("/api/login", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+  errors.value = [];
+  if (!username.value) errors.value.push('Username is required');
+  if (!password.value) errors.value.push('Password is required');
+  if (mode.value === 'register') {
+    if (!email.value) {
+      errors.value.push('Email is required');
+    } else if (!/^\S+@\S+\.\S+$/.test(email.value)) {
+      errors.value.push('Email must be valid');
+    }
+  }
+  if (errors.value.length) return;
+
+  if (mode.value === 'login') {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         Username: username.value,
         Password: password.value,
@@ -57,14 +108,15 @@ async function submit() {
       }),
     });
     if (res.status === 401) {
-      alert("login failed");
+      errors.value.push('Login failed');
     } else if (res.ok) {
+      emit('success');
       window.location.reload();
     }
   } else {
-    const res = await fetch("/api/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         Username: username.value,
         Email: email.value,
@@ -72,10 +124,9 @@ async function submit() {
       }),
     });
     if (!res.ok) {
-      alert("register failed");
+      errors.value.push('Register failed');
     } else {
-      alert("registered, awaiting verification");
-      mode.value = "login";
+      mode.value = 'login';
     }
   }
 }


### PR DESCRIPTION
## Summary
- apply Tailwind utility classes to root page
- restyle login/register modal in dark theme and add close button
- add keyboard and click handlers for closing modal
- add accessible form labels and validation messages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687136fd7ac4832290794819c5b4ec4e