### PR TITLE
Implement auth middleware

### DIFF
--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -29,15 +29,15 @@ var serveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// All API endpoints are now grouped under the /api prefix so the
 		// root path only serves the client UI.
-		http.HandleFunc("/api/chat", handlers2.ChatHandler)
-		http.HandleFunc("/api/projects", handlers2.ProjectsHandler)
-		http.HandleFunc("/api/projects/switch", handlers2.SwitchProjectHandler)
-		http.HandleFunc("/api/projects/rename", handlers2.RenameProjectHandler)
-		http.HandleFunc("/api/projects/", handlers2.DeleteProjectHandler)
+		http.HandleFunc("/api/chat", handlers2.WithAuth(handlers2.ChatHandler))
+		http.HandleFunc("/api/projects", handlers2.WithAuth(handlers2.ProjectsHandler))
+		http.HandleFunc("/api/projects/switch", handlers2.WithAuth(handlers2.SwitchProjectHandler))
+		http.HandleFunc("/api/projects/rename", handlers2.WithAuth(handlers2.RenameProjectHandler))
+		http.HandleFunc("/api/projects/", handlers2.WithAuth(handlers2.DeleteProjectHandler))
 		http.HandleFunc("/api/register", handlers2.RegisterHandler)
 		http.HandleFunc("/api/login", handlers2.LoginHandler)
 		http.HandleFunc("/api/logout", handlers2.LogoutHandler)
-		http.HandleFunc("/api/users", handlers2.UsersHandler)
+		http.HandleFunc("/api/users", handlers2.WithAdmin(handlers2.UsersHandler))
 
 		// Serve the web UI. Prefer the built client under /client when
 		// running in Docker, but fall back to the source directory for

--- a/src/handlers/chat.go
+++ b/src/handlers/chat.go
@@ -15,8 +15,6 @@ import (
 	"encoding/json"
 	_ "io"
 	"net/http"
-	"strconv"
-	"time"
 )
 
 // ChatRequest is the JSON payload accepted by the chat endpoint. It simply

--- a/src/handlers/middleware.go
+++ b/src/handlers/middleware.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"codex/src/auth"
+	"codex/src/memory"
+	"net/http"
+	"strconv"
+)
+
+// WithAuth ensures the request has a valid session cookie. If the cookie is
+// missing or does not map to a user account a 401 response is returned.
+func WithAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		c, err := r.Cookie("session")
+		if err != nil || c.Value == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		id, err := strconv.Atoi(c.Value)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		db, err := memory.InitDB()
+		if err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		defer db.Close()
+		if _, err := auth.GetByID(db, id); err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// WithAdmin ensures the requester is both authenticated and marked as an admin
+// in the database. Non-admin users receive a 403 response.
+func WithAdmin(next http.HandlerFunc) http.HandlerFunc {
+	return WithAuth(func(w http.ResponseWriter, r *http.Request) {
+		c, _ := r.Cookie("session")
+		id, _ := strconv.Atoi(c.Value)
+		db, err := memory.InitDB()
+		if err != nil {
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		defer db.Close()
+		u, err := auth.GetByID(db, id)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if !u.Admin {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		next(w, r)
+	})
+}


### PR DESCRIPTION
## Summary
- add `GetByID` helper to look up users by id
- secure server endpoints with new `WithAuth` and `WithAdmin` middleware
- update tests to use authentication wrappers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687137d26fcc83229f6a7e2131abfd57