### PR TITLE
Use signed secure cookies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module codex
 go 1.24
 
 require (
+	github.com/gorilla/securecookie v1.1.2
 	github.com/mattn/go-sqlite3 v1.14.28
+	github.com/pquerna/otp v1.3.0
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/crypto v0.40.0
 )
 
 require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pquerna/otp v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	golang.org/x/crypto v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,17 @@
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
+github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
 github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
@@ -15,6 +21,7 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
 golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=

--- a/src/handlers/chat.go
+++ b/src/handlers/chat.go
@@ -47,7 +47,13 @@ func ensureAnonCookie(w http.ResponseWriter, r *http.Request) string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err == nil {
 		id := hex.EncodeToString(b)
-		http.SetCookie(w, &http.Cookie{Name: "anon", Value: id, Path: "/"})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "anon",
+			Value:    id,
+			Path:     "/",
+			Secure:   true,
+			SameSite: http.SameSiteStrictMode,
+		})
 		return id
 	}
 	return ""

--- a/src/handlers/chat_test.go
+++ b/src/handlers/chat_test.go
@@ -67,7 +67,8 @@ func TestChatHandlerSuccess(t *testing.T) {
 
 	body := bytes.NewBufferString(`{"prompt":"hi"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/chat", body)
-	req.AddCookie(&http.Cookie{Name: "session", Value: "1"})
+	val, _ := sc.Encode("session", 1)
+	req.AddCookie(&http.Cookie{Name: "session", Value: val})
 	w := httptest.NewRecorder()
 	WithAuth(ChatHandler)(w, req)
 	res := w.Result()

--- a/src/handlers/middleware.go
+++ b/src/handlers/middleware.go
@@ -4,20 +4,14 @@ import (
 	"codex/src/auth"
 	"codex/src/memory"
 	"net/http"
-	"strconv"
 )
 
 // WithAuth ensures the request has a valid session cookie. If the cookie is
 // missing or does not map to a user account a 401 response is returned.
 func WithAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		c, err := r.Cookie("session")
-		if err != nil || c.Value == "" {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		id, err := strconv.Atoi(c.Value)
-		if err != nil {
+		id, err := getSessionID(r)
+		if err != nil || id == 0 {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -39,8 +33,7 @@ func WithAuth(next http.HandlerFunc) http.HandlerFunc {
 // in the database. Non-admin users receive a 403 response.
 func WithAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return WithAuth(func(w http.ResponseWriter, r *http.Request) {
-		c, _ := r.Cookie("session")
-		id, _ := strconv.Atoi(c.Value)
+		id, _ := getSessionID(r)
 		db, err := memory.InitDB()
 		if err != nil {
 			http.Error(w, "db error", http.StatusInternalServerError)

--- a/src/handlers/project_test.go
+++ b/src/handlers/project_test.go
@@ -41,7 +41,8 @@ func TestProjectAPI(t *testing.T) {
 	cleanup := setupTempDB(t)
 	defer cleanup()
 
-	cookie := &http.Cookie{Name: "session", Value: "1"}
+	val, _ := sc.Encode("session", 1)
+	cookie := &http.Cookie{Name: "session", Value: val}
 
 	// create project p1
 	body := bytes.NewBufferString(`{"name":"p1"}`)

--- a/src/handlers/session.go
+++ b/src/handlers/session.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"github.com/gorilla/securecookie"
+	"net/http"
+	"os"
+)
+
+var sc *securecookie.SecureCookie
+
+func init() {
+	hashKey := []byte(os.Getenv("CODEX_COOKIE_HASH"))
+	if len(hashKey) == 0 {
+		// default 32 bytes key if not provided
+		hashKey = []byte("default-secret-change-me-----")
+	}
+	sc = securecookie.New(hashKey, nil)
+}
+
+func setSessionCookie(w http.ResponseWriter, id int) error {
+	encoded, err := sc.Encode("session", id)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    encoded,
+		Path:     "/",
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+	return nil
+}
+
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func getSessionID(r *http.Request) (int, error) {
+	c, err := r.Cookie("session")
+	if err != nil || c.Value == "" {
+		return 0, err
+	}
+	var id int
+	if err := sc.Decode("session", c.Value, &id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -10,7 +10,6 @@ import (
 	"codex/src/memory"
 	"encoding/json"
 	"net/http"
-	"strconv"
 )
 
 // RegisterHandler creates a new user account.
@@ -59,13 +58,16 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	http.SetCookie(w, &http.Cookie{Name: "session", Value: strconv.Itoa(u.ID), Path: "/"})
+	if err := setSessionCookie(w, u.ID); err != nil {
+		http.Error(w, "server error", http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
 // LogoutHandler clears the session cookie.
 func LogoutHandler(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{Name: "session", Value: "", Path: "/", MaxAge: -1})
+	clearSessionCookie(w)
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
## Summary
- sign cookies with gorilla/securecookie and add helper functions
- secure anon cookie with `Secure` and `SameSite` flags
- update login/logout and middleware to use signed cookies
- update tests to work with encoded values

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68713a0ee5108322b81f78b58d7ca262