### PR TITLE
Add account verification and password reset support

### DIFF
--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -38,6 +38,9 @@ var serveCmd = &cobra.Command{
 		http.HandleFunc("/api/login", handlers2.LoginHandler)
 		http.HandleFunc("/api/logout", handlers2.LogoutHandler)
 		http.HandleFunc("/api/users", handlers2.WithAdmin(handlers2.UsersHandler))
+		http.HandleFunc("/api/verify", handlers2.VerifyHandler)
+		http.HandleFunc("/api/reset/request", handlers2.ResetRequestHandler)
+		http.HandleFunc("/api/reset", handlers2.ResetPasswordHandler)
 
 		// Serve the web UI. Prefer the built client under /client when
 		// running in Docker, but fall back to the source directory for

--- a/src/email/email.go
+++ b/src/email/email.go
@@ -1,0 +1,15 @@
+package email
+
+import "log"
+
+// SendFunc is used by Send to dispatch email messages. It can be replaced
+// in tests to capture outgoing emails.
+var SendFunc = func(to, subject, body string) error {
+	log.Printf("sending email to %s: %s - %s", to, subject, body)
+	return nil
+}
+
+// Send delivers an email using the configured SendFunc.
+func Send(to, subject, body string) error {
+	return SendFunc(to, subject, body)
+}

--- a/src/memory/memory.go
+++ b/src/memory/memory.go
@@ -67,6 +67,15 @@ func InitDB() (*sql.DB, error) {
 	}
 	// attempt to add admin column if the table already existed without it
 	db.Exec(`ALTER TABLE users ADD COLUMN admin INTEGER DEFAULT 0`)
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS tokens (
+               token TEXT PRIMARY KEY,
+               user_id INTEGER,
+               type TEXT,
+               expires DATETIME
+       );`); err != nil {
+		db.Close()
+		return nil, err
+	}
 	return db, nil
 }
 


### PR DESCRIPTION
## Summary
- add simple email package for outgoing messages
- store single-use tokens in database
- send verification link on registration
- allow requesting and completing password resets
- expose `/api/verify` and `/api/reset` routes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687158ee3440832288dbbef110cf73fd