### PR TITLE
Add password reset flow

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -42,7 +42,7 @@ func SendReset(db *sql.DB, u *User) error {
 	if err != nil {
 		return err
 	}
-	link := "http://localhost:8081/reset?token=" + token
+	link := "http://localhost:8081/reset/?token=" + token
 	body := "Use this link to reset your password: " + link
 	return email.Send(u.Email, "Codex password reset", body)
 }

--- a/src/client/reset/index.html
+++ b/src/client/reset/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Set New Password</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="/src/index.css">
+  </head>
+  <body class="h-full bg-gray-900 text-gray-200 flex items-center justify-center">
+    <form id="reset-form" class="space-y-4 bg-gray-800 p-6 rounded">
+      <h2 class="text-xl font-semibold text-center">Set New Password</h2>
+      <div class="relative">
+        <label for="pass1" class="sr-only">Password</label>
+        <input id="pass1" type="password" required placeholder="Password" class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200" />
+        <span id="toggle1" class="material-icons absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer">visibility</span>
+      </div>
+      <div class="relative">
+        <label for="pass2" class="sr-only">Confirm Password</label>
+        <input id="pass2" type="password" required placeholder="Confirm Password" class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200" />
+        <span id="toggle2" class="material-icons absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer">visibility</span>
+      </div>
+      <p id="msg" class="text-red-400 text-center"></p>
+      <button class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-500">Change Password</button>
+    </form>
+    <script type="module">
+      const params = new URLSearchParams(location.search);
+      const token = params.get('token');
+      const msg = document.getElementById('msg');
+      if (!token) {
+        msg.textContent = 'Invalid reset link';
+      }
+      const pass1 = document.getElementById('pass1');
+      const pass2 = document.getElementById('pass2');
+      document.getElementById('toggle1').addEventListener('click', () => {
+        pass1.type = pass1.type === 'password' ? 'text' : 'password';
+      });
+      document.getElementById('toggle2').addEventListener('click', () => {
+        pass2.type = pass2.type === 'password' ? 'text' : 'password';
+      });
+      document.getElementById('reset-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (pass1.value !== pass2.value) {
+          msg.textContent = 'Passwords do not match';
+          return;
+        }
+        const res = await fetch('/api/reset', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ Token: token, Password: pass1.value })
+        });
+        if (res.ok) {
+          msg.textContent = 'Password updated';
+          msg.classList.remove('text-red-400');
+          msg.classList.add('text-green-400');
+        } else {
+          msg.textContent = 'Reset failed';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/client/reset/request/index.html
+++ b/src/client/reset/request/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reset Password</title>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="/src/index.css">
+  </head>
+  <body class="h-full bg-gray-900 text-gray-200 flex items-center justify-center">
+    <form id="req-form" class="space-y-4 bg-gray-800 p-6 rounded">
+      <h2 class="text-xl font-semibold text-center">Reset Password</h2>
+      <div>
+        <label for="email" class="sr-only">Email</label>
+        <input id="email" type="email" required placeholder="Email" class="w-full p-2 rounded bg-gray-700 border border-gray-600 placeholder-gray-400 text-gray-200" />
+      </div>
+      <p id="msg" class="hidden text-green-400 text-center"></p>
+      <button class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-500">Send Reset Email</button>
+    </form>
+    <script type="module">
+      const form = document.getElementById('req-form');
+      const msg = document.getElementById('msg');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = (document.getElementById('email') as HTMLInputElement).value;
+        await fetch('/api/reset/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ Email: email })
+        });
+        msg.textContent = 'If that email exists, a reset link has been sent.';
+        msg.classList.remove('hidden');
+      });
+    </script>
+  </body>
+</html>

--- a/src/client/src/components/Login.vue
+++ b/src/client/src/components/Login.vue
@@ -68,6 +68,9 @@
           : 'Need an account? Register'
       }}</a>
     </p>
+    <p v-if="mode === 'login'" class="text-sm text-center">
+      <a href="/reset/request/" class="underline">Forgot password?</a>
+    </p>
   </form>
 </template>
 


### PR DESCRIPTION
## Summary
- link to a password reset form from the login modal
- serve a page to request a reset email
- serve a page to set a new password using the token
- update reset email to include trailing slash in link

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687160eacc6c832289cf61defc701613