### PR TITLE
Fix missing password reset pages

### DIFF
--- a/src/client/reset/request/index.html
+++ b/src/client/reset/request/index.html
@@ -22,7 +22,7 @@
       const msg = document.getElementById('msg');
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const email = (document.getElementById('email') as HTMLInputElement).value;
+        const email = document.getElementById('email').value;
         await fetch('/api/reset/request', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/client/vite.config.js
+++ b/src/client/vite.config.js
@@ -1,11 +1,21 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
 
 export default defineConfig({
   plugins: [vue()],
   server: {
     proxy: {
       '/api': 'http://localhost:8080'
+    }
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        reset: resolve(__dirname, 'reset/index.html'),
+        request: resolve(__dirname, 'reset/request/index.html')
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- include password reset HTML pages in the production build
- fix TypeScript syntax in the reset request page so it works when served statically

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687166358218832288ef3bcc51e628d2