### PR TITLE
Add admin model management view

### DIFF
--- a/src/client/src/api.ts
+++ b/src/client/src/api.ts
@@ -1,15 +1,32 @@
 export interface User {
-  id: number
-  username: string
-  email?: string
-  admin?: boolean | number
-  verified?: boolean | number
+  id: number;
+  username: string;
+  email?: string;
+  admin?: boolean | number;
+  verified?: boolean | number;
 }
 
 export async function fetchUsers(): Promise<User[]> {
-  const res = await fetch('/api/users')
+  const res = await fetch("/api/users");
   if (!res.ok) {
-    throw new Error('Failed to fetch users')
+    throw new Error("Failed to fetch users");
   }
-  return res.json()
+  return res.json();
+}
+
+export interface ModelInfo {
+  modelId: string;
+  lastModified: string;
+  downloads: number;
+  tags: string[];
+}
+
+export async function fetchModels(pipeline: string): Promise<ModelInfo[]> {
+  const res = await fetch(
+    "/api/models?pipeline=" + encodeURIComponent(pipeline),
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch models");
+  }
+  return res.json();
 }

--- a/src/client/src/components/AdminLayout.vue
+++ b/src/client/src/components/AdminLayout.vue
@@ -1,24 +1,63 @@
 <template>
-  <div class="p-4">
-    <h1 class="text-xl mb-2">Admin</h1>
-    <ul>
-      <li v-for="u in users" :key="u.id">{{ u.username }} <span v-if="!u.verified">(unverified)</span></li>
-    </ul>
+  <div class="flex h-full bg-gray-900 text-gray-200">
+    <nav class="bg-gray-800 w-48 p-4 space-y-2">
+      <h2 class="text-lg mb-2">Admin</h2>
+      <ul class="space-y-1 text-sm">
+        <li>
+          <button
+            @click="page = 'users'"
+            :class="linkClass('users')"
+            class="w-full text-left"
+          >
+            Users
+          </button>
+        </li>
+        <li>
+          <button
+            @click="page = 'models'"
+            :class="linkClass('models')"
+            class="w-full text-left"
+          >
+            Manage Models
+          </button>
+        </li>
+      </ul>
+    </nav>
+    <main class="flex-1 p-4 overflow-y-auto">
+      <div v-if="page === 'users'">
+        <h1 class="text-xl mb-2">Users</h1>
+        <ul>
+          <li v-for="u in users" :key="u.id">
+            {{ u.username }} <span v-if="!u.verified">(unverified)</span>
+          </li>
+        </ul>
+      </div>
+      <ManageModels v-else />
+    </main>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { fetchUsers, type User } from '../api'
-const users = ref<User[]>([])
+import { ref, onMounted } from "vue";
+import { fetchUsers, type User } from "../api";
+import ManageModels from "./ManageModels.vue";
 
-onMounted(async () => {
+const page = ref<"users" | "models">("users");
+const users = ref<User[]>([]);
+
+function linkClass(p: "users" | "models") {
+  return page.value === p ? "font-semibold" : "hover:underline";
+}
+
+async function loadUsers() {
   try {
-    users.value = await fetchUsers()
+    users.value = await fetchUsers();
   } catch {
-    users.value = []
+    users.value = [];
   }
-})
+}
+
+onMounted(loadUsers);
 </script>
 
 <style scoped></style>

--- a/src/client/src/components/ManageModels.vue
+++ b/src/client/src/components/ManageModels.vue
@@ -1,0 +1,65 @@
+<template>
+  <div>
+    <div class="border-b border-gray-700 mb-4">
+      <nav class="flex space-x-4 text-sm">
+        <button
+          v-for="p in pipelines"
+          :key="p"
+          @click="select(p)"
+          :class="[tabClass(p), 'pb-1']"
+        >
+          {{ p }}
+        </button>
+      </nav>
+    </div>
+    <div v-if="loading" class="py-2">Loading...</div>
+    <ul v-else class="space-y-1 text-sm">
+      <li v-for="m in models" :key="m.modelId" class="truncate">
+        {{ m.modelId }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { fetchModels, type ModelInfo } from "../api";
+
+const pipelines = [
+  "text-generation",
+  "text2text-generation",
+  "text-classification",
+  "code",
+  "conversational",
+];
+
+const selected = ref(pipelines[0]);
+const models = ref<ModelInfo[]>([]);
+const loading = ref(false);
+
+async function load() {
+  loading.value = true;
+  try {
+    models.value = await fetchModels(selected.value);
+  } catch {
+    models.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+function select(p: string) {
+  selected.value = p;
+  load();
+}
+
+function tabClass(p: string) {
+  return selected.value === p
+    ? "border-b-2 border-blue-500"
+    : "hover:text-gray-300";
+}
+
+load();
+</script>
+
+<style scoped></style>

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -38,6 +38,7 @@ var serveCmd = &cobra.Command{
 		http.HandleFunc("/api/login", handlers2.LoginHandler)
 		http.HandleFunc("/api/logout", handlers2.LogoutHandler)
 		http.HandleFunc("/api/users", handlers2.WithAdmin(handlers2.UsersHandler))
+		http.HandleFunc("/api/models", handlers2.WithAdmin(handlers2.ModelsHandler))
 		http.HandleFunc("/api/verify", handlers2.VerifyHandler)
 		http.HandleFunc("/api/reset/request", handlers2.ResetRequestHandler)
 		http.HandleFunc("/api/reset", handlers2.ResetPasswordHandler)

--- a/src/handlers/models.go
+++ b/src/handlers/models.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"codex/src/models"
+	"encoding/json"
+	"net/http"
+)
+
+// ModelsHandler lists Hugging Face models for a pipeline type.
+// It requires the `pipeline` query parameter.
+func ModelsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	pipeline := r.URL.Query().Get("pipeline")
+	if pipeline == "" {
+		http.Error(w, "pipeline required", http.StatusBadRequest)
+		return
+	}
+	list, err := models.ListModelsByType(pipeline)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}


### PR DESCRIPTION
## Summary
- create Admin side menu with Users and Manage Models sections
- implement Manage Models tabbed page listing HuggingFace models
- expose `/api/models` endpoint for admins

## Testing
- `go test ./...`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68716af6e76c8322af42a5b6c5ebf92e