### PR TITLE
Fix reset password forms

### DIFF
--- a/src/client/reset/index.html
+++ b/src/client/reset/index.html
@@ -24,38 +24,40 @@
       <button class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-500">Change Password</button>
     </form>
     <script type="module">
-      const params = new URLSearchParams(location.search);
-      const token = params.get('token');
-      const msg = document.getElementById('msg');
-      if (!token) {
-        msg.textContent = 'Invalid reset link';
-      }
-      const pass1 = document.getElementById('pass1');
-      const pass2 = document.getElementById('pass2');
-      document.getElementById('toggle1').addEventListener('click', () => {
-        pass1.type = pass1.type === 'password' ? 'text' : 'password';
-      });
-      document.getElementById('toggle2').addEventListener('click', () => {
-        pass2.type = pass2.type === 'password' ? 'text' : 'password';
-      });
-      document.getElementById('reset-form').addEventListener('submit', async (e) => {
-        e.preventDefault();
-        if (pass1.value !== pass2.value) {
-          msg.textContent = 'Passwords do not match';
-          return;
+      window.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(location.search);
+        const token = params.get('token');
+        const msg = document.getElementById('msg');
+        if (!token) {
+          msg.textContent = 'Invalid reset link';
         }
-        const res = await fetch('/api/reset', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ Token: token, Password: pass1.value })
+        const pass1 = document.getElementById('pass1');
+        const pass2 = document.getElementById('pass2');
+        document.getElementById('toggle1').addEventListener('click', () => {
+          pass1.type = pass1.type === 'password' ? 'text' : 'password';
         });
-        if (res.ok) {
-          msg.textContent = 'Password updated';
-          msg.classList.remove('text-red-400');
-          msg.classList.add('text-green-400');
-        } else {
-          msg.textContent = 'Reset failed';
-        }
+        document.getElementById('toggle2').addEventListener('click', () => {
+          pass2.type = pass2.type === 'password' ? 'text' : 'password';
+        });
+        document.getElementById('reset-form').addEventListener('submit', async (e) => {
+          e.preventDefault();
+          if (pass1.value !== pass2.value) {
+            msg.textContent = 'Passwords do not match';
+            return;
+          }
+          const res = await fetch('/api/reset', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ Token: token, Password: pass1.value })
+          });
+          if (res.ok) {
+            msg.textContent = 'Password updated';
+            msg.classList.remove('text-red-400');
+            msg.classList.add('text-green-400');
+          } else {
+            msg.textContent = 'Reset failed';
+          }
+        });
       });
     </script>
   </body>

--- a/src/client/reset/request/index.html
+++ b/src/client/reset/request/index.html
@@ -18,18 +18,20 @@
       <button class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-500">Send Reset Email</button>
     </form>
     <script type="module">
-      const form = document.getElementById('req-form');
-      const msg = document.getElementById('msg');
-      form.addEventListener('submit', async (e) => {
-        e.preventDefault();
-        const email = document.getElementById('email').value;
-        await fetch('/api/reset/request', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ Email: email })
+      window.addEventListener('DOMContentLoaded', () => {
+        const form = document.getElementById('req-form');
+        const msg = document.getElementById('msg');
+        form.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const email = document.getElementById('email').value;
+          await fetch('/api/reset/request', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ Email: email })
+          });
+          msg.textContent = 'If that email exists, a reset link has been sent.';
+          msg.classList.remove('hidden');
         });
-        msg.textContent = 'If that email exists, a reset link has been sent.';
-        msg.classList.remove('hidden');
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- ensure reset request form waits for DOMContentLoaded before attaching handler
- ensure reset page script runs after DOM is ready

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68716efd700c83229d2165329d6a1f40