### PR TITLE
Add email sending via SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ services is via Docker Compose:
 docker-compose up
 ```
 
+The compose file includes an SMTP server under the `mail` service. The Codex
+container sends email notifications through this server using the environment
+variables `SMTP_ADDR` and `SMTP_FROM`.
+
 ### CLI commands
 
 - `codex add [project] [role] [content]` – store a message in memory

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,11 +8,20 @@ services:
       - "8080:8080"
     command: ["--model", "/models/your-model.gguf"]
 
+  mail:
+    image: namshi/smtp
+    ports:
+      - "1025:25"
+
   codex:
     build: .
     depends_on:
       - llama
+      - mail
     ports:
       - "8081:8081"
+    environment:
+      - SMTP_ADDR=mail:25
+      - SMTP_FROM=codex@example.com
     volumes:
       - ./data:/data

--- a/src/email/email.go
+++ b/src/email/email.go
@@ -1,12 +1,39 @@
 package email
 
-import "log"
+import (
+	"log"
+	"net/smtp"
+	"os"
+)
 
 // SendFunc is used by Send to dispatch email messages. It can be replaced
 // in tests to capture outgoing emails.
 var SendFunc = func(to, subject, body string) error {
-	log.Printf("sending email to %s: %s - %s", to, subject, body)
+	from := smtpFrom()
+	addr := smtpAddr()
+	msg := []byte("From: " + from + "\r\n" +
+		"To: " + to + "\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"\r\n" + body + "\r\n")
+	if err := smtp.SendMail(addr, nil, from, []string{to}, msg); err != nil {
+		return err
+	}
+	log.Printf("sent email to %s via %s", to, addr)
 	return nil
+}
+
+func smtpAddr() string {
+	if v := os.Getenv("SMTP_ADDR"); v != "" {
+		return v
+	}
+	return "localhost:25"
+}
+
+func smtpFrom() string {
+	if v := os.Getenv("SMTP_FROM"); v != "" {
+		return v
+	}
+	return "codex@example.com"
 }
 
 // Send delivers an email using the configured SendFunc.


### PR DESCRIPTION
## Summary
- add `mail` service to docker-compose
- use `SMTP_ADDR` and `SMTP_FROM` to send emails via SMTP
- document mail service and env vars in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687174c1ee448322a4f2cc6641b47442