### PR TITLE
Remove TOTP from login

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -211,8 +211,8 @@ func List(db *sql.DB) ([]User, error) {
 	return res, nil
 }
 
-// Authenticate attempts to retrieve the user by username and verify credentials and optional TOTP.
-func Authenticate(db *sql.DB, username, password, code string) (*User, error) {
+// Authenticate attempts to retrieve the user by username and verify credentials.
+func Authenticate(db *sql.DB, username, password string) (*User, error) {
 	u, err := GetByUsername(db, username)
 	if err != nil {
 		return nil, err
@@ -222,9 +222,6 @@ func Authenticate(db *sql.DB, username, password, code string) (*User, error) {
 	}
 	if err := VerifyPassword(u, password); err != nil {
 		return nil, err
-	}
-	if u.TOTPSecret != "" && !VerifyTOTP(u.TOTPSecret, code) {
-		return nil, errors.New("invalid totp")
 	}
 	return u, nil
 }

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -46,7 +46,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	var req struct{ Username, Password, TOTP string }
+	var req struct{ Username, Password string }
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid", http.StatusBadRequest)
 		return
@@ -57,7 +57,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer db.Close()
-	u, err := auth.Authenticate(db, req.Username, req.Password, req.TOTP)
+	u, err := auth.Authenticate(db, req.Username, req.Password)
 	if err != nil {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return


### PR DESCRIPTION
## Summary
- strip TOTP fields from the login handler
- drop TOTP validation from `auth.Authenticate`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68723d3f24a48322b5de90cdf9b19dd4