### PR TITLE
Fix login button state after successful login

### DIFF
--- a/src/client/src/App.vue
+++ b/src/client/src/App.vue
@@ -39,7 +39,7 @@
         >
           &times;
         </button>
-        <LoginForm @success="closeLogin" @register="openRegister" @reset="openReset" />
+        <LoginForm @success="loginSuccess" @register="openRegister" @reset="openReset" />
       </div>
     </div>
 
@@ -131,6 +131,12 @@ function openReset() {
 function switchToLogin() {
   closeRegister()
   openLogin()
+}
+
+function loginSuccess() {
+  closeLogin()
+  parseSession()
+  fetchUsername()
 }
 
 function handleKey(e: KeyboardEvent) {

--- a/src/client/src/components/LoginForm.vue
+++ b/src/client/src/components/LoginForm.vue
@@ -73,7 +73,6 @@ async function submit() {
     errors.value.push('Login failed')
   } else if (res.ok) {
     emit('success')
-    window.location.reload()
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- when login succeeds, update user state without page reload
- remove reload logic in login form

## Testing
- `npm run build` in `src/client`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872564f88f483228bec9664f1d19303