### PR TITLE
Improve session cookie handling in frontend

### DIFF
--- a/src/client/src/App.vue
+++ b/src/client/src/App.vue
@@ -133,10 +133,13 @@ function switchToLogin() {
   openLogin()
 }
 
-function loginSuccess() {
+function loginSuccess(user: User) {
   closeLogin()
-  parseSession()
-  fetchUsername()
+  loggedIn.value = true
+  userId.value = user.id
+  username.value = user.username
+  isAdmin.value = user.admin === true || user.admin === 1
+  localStorage.setItem('codexUser', JSON.stringify(user))
 }
 
 function handleKey(e: KeyboardEvent) {
@@ -156,10 +159,18 @@ watch([showLogin, showRegister, showReset], ([l, r, s]) => {
 })
 
 function parseSession() {
-  const match = document.cookie.match(/session=(\d+)/)
-  if (match) {
+  const has = document.cookie.match(/(?:^|;)\s*session=/)
+  if (has) {
     loggedIn.value = true
-    userId.value = parseInt(match[1])
+    const stored = localStorage.getItem('codexUser')
+    if (stored) {
+      try {
+        const u: User = JSON.parse(stored)
+        userId.value = u.id
+        username.value = u.username
+        isAdmin.value = u.admin === true || u.admin === 1
+      } catch {}
+    }
   }
 }
 
@@ -177,6 +188,7 @@ async function fetchUsername() {
 
 function logout() {
   fetch('/api/logout', { method: 'POST' }).finally(() => {
+    localStorage.removeItem('codexUser')
     window.location.reload()
   })
 }

--- a/src/client/src/components/LoginForm.vue
+++ b/src/client/src/components/LoginForm.vue
@@ -50,7 +50,7 @@ const code = ref('')
 const errors = ref<string[]>([])
 
 const emit = defineEmits<{
-  (e: 'success'): void
+  (e: 'success', user: any): void
   (e: 'register'): void
   (e: 'reset'): void
 }>()
@@ -72,7 +72,8 @@ async function submit() {
   if (res.status === 401) {
     errors.value.push('Login failed')
   } else if (res.ok) {
-    emit('success')
+    const user = await res.json()
+    emit('success', user)
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- fix session persistence logic
- return login user data to App via LoginForm
- store user info in localStorage for reuse
- clear stored data on logout

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68725b2cdf8c83229644ffd4065ee69d