### PR TITLE
Enable models from admin UI

### DIFF
--- a/src/client/src/services/models.ts
+++ b/src/client/src/services/models.ts
@@ -53,3 +53,9 @@ export async function syncModels(): Promise<void> {
   const res = await fetch(`${BASE}/sync`, { method: 'POST' })
   if (!res.ok) throw new Error('Failed to sync models')
 }
+
+export async function enableModel(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/${encodeURIComponent(id)}/enable`, { method: 'POST' })
+  if (!res.ok) throw new Error('Failed to enable model')
+}
+

--- a/src/client/src/views/admin/ModelList.vue
+++ b/src/client/src/views/admin/ModelList.vue
@@ -14,8 +14,9 @@
     </div>
     <div v-if="loading" class="py-2">Loading...</div>
     <ul v-else class="space-y-1 text-sm">
-      <li v-for="m in models" :key="m.modelId" class="truncate">
+      <li v-for="m in models" :key="m.modelId" class="truncate flex items-center space-x-2">
         <ModelCard>{{ m.modelId }}</ModelCard>
+        <button @click="enable(m.modelId)" class="text-xs text-blue-400 hover:underline">Enable</button>
       </li>
     </ul>
   </div>
@@ -24,7 +25,7 @@
 <script setup lang="ts">
 // View for listing all models. Formerly `ManageModels.vue`.
 import { ref } from 'vue'
-import { getAllModels, type Model } from '../../services/models'
+import { getAllModels, enableModel, type Model } from '../../services/models'
 import ModelCard from '../../components/model/ModelCard.vue'
 
 const pipelines = [
@@ -53,6 +54,15 @@ async function load() {
 function select(p: string) {
   selected.value = p;
   load();
+}
+
+async function enable(id: string) {
+  try {
+    await enableModel(id)
+    alert('Model enabled')
+  } catch {
+    alert('Failed to enable model')
+  }
 }
 
 function tabClass(p: string) {

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -39,6 +39,7 @@ var serveCmd = &cobra.Command{
 		http.HandleFunc("/api/logout", handlers2.LogoutHandler)
 		http.HandleFunc("/api/users", handlers2.WithAdmin(handlers2.UsersHandler))
 		http.HandleFunc("/api/models", handlers2.WithAdmin(handlers2.ModelsHandler))
+		http.HandleFunc("/api/models/", handlers2.WithAdmin(handlers2.EnableModelHandler))
 		http.HandleFunc("/api/verify", handlers2.VerifyHandler)
 		http.HandleFunc("/api/reset/request", handlers2.ResetRequestHandler)
 		http.HandleFunc("/api/reset", handlers2.ResetPasswordHandler)

--- a/src/handlers/models.go
+++ b/src/handlers/models.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"codex/src/llama"
 	"codex/src/models"
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // ModelsHandler lists Hugging Face models for a pipeline type.
@@ -25,4 +27,29 @@ func ModelsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
+}
+
+// EnableModelHandler downloads and activates the requested model ID then
+// instructs the llama server to reload the model from disk.
+func EnableModelHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/models/"), "/")
+	if len(parts) < 2 || parts[1] != "enable" {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	id := parts[0]
+	path, err := models.EnableModel(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := llama.LoadModel(path); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
## Summary
- add backend ability to enable models
- hook llama server reload via `/props`
- expose POST `/api/models/{id}/enable`
- add service and button in ModelList.vue to trigger enable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687265100fd08322a0b648e4039c6814