### PR TITLE
Improve admin model management

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ variables `SMTP_ADDR` and `SMTP_FROM`.
 
 Run `codex [command] --help` for detailed flags.
 
+### Admin model management
+
+Logged in administrators can manage models from the web UI under
+`/admin/models`. The interface lists Hugging Face models for each pipeline
+category, supports searching by ID, and allows downloading or activating a
+model. Selecting a model displays detailed metadata including tags, SHA and file
+list retrieved from the Hugging Face API. A separate stats view shows the total
+number of models available across Hugging Face.
+
 ## Data location
 
 All conversation history and project metadata are kept in `memory.db` in the

--- a/src/client/src/services/models.ts
+++ b/src/client/src/services/models.ts
@@ -1,6 +1,6 @@
 // Centralized API calls for model management.
 // Moved from api.ts and expanded with clear method names.
-import type { Model } from "../types/models";
+import type { Model, ModelDetail, GlobalStats } from "../types/models";
 
 const BASE = "/api/models";
 
@@ -17,13 +17,13 @@ export async function getActiveModels(): Promise<Model[]> {
   return res.json();
 }
 
-export async function getModelById(id: string): Promise<Model> {
+export async function getModelById(id: string): Promise<ModelDetail> {
   const res = await fetch(`${BASE}/${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error("Failed to fetch model");
   return res.json();
 }
 
-export async function getModelStats(id: string): Promise<any> {
+export async function getModelStats(id: string): Promise<ModelDetail> {
   const res = await fetch(`${BASE}/${encodeURIComponent(id)}/stats`);
   if (!res.ok) throw new Error("Failed to fetch model stats");
   return res.json();
@@ -43,7 +43,7 @@ export async function deactivateModel(id: string): Promise<void> {
   if (!res.ok) throw new Error("Failed to deactivate model");
 }
 
-export async function getGlobalStats(): Promise<any> {
+export async function getGlobalStats(): Promise<GlobalStats> {
   const res = await fetch(`${BASE}/stats/global`);
   if (!res.ok) throw new Error("Failed to fetch global stats");
   return res.json();

--- a/src/client/src/types/models.ts
+++ b/src/client/src/types/models.ts
@@ -5,12 +5,16 @@ export interface Model {
   tags: string[];
 }
 
+export interface ModelDetail extends Model {
+  sha: string;
+  files: string[];
+}
+
 export interface ModelStats {
   // placeholder for per-model stats
   [key: string]: unknown;
 }
 
 export interface GlobalStats {
-  // placeholder for global stats
-  [key: string]: unknown;
+  total_models: number;
 }

--- a/src/client/src/views/admin/GlobalModelStats.vue
+++ b/src/client/src/views/admin/GlobalModelStats.vue
@@ -1,12 +1,30 @@
 <template>
   <div>
     <h1 class="text-xl mb-2">Global Model Stats</h1>
-    <p>Overall stats placeholder.</p>
+    <div v-if="loading">Loading...</div>
+    <div v-else class="text-sm">
+      Total models available: {{ stats?.total_models }}
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Placeholder for global model stats.
+import { ref } from "vue";
+import { getGlobalStats, type GlobalStats } from "../../services/models";
+
+const loading = ref(true);
+const stats = ref<GlobalStats | null>(null);
+
+async function load() {
+  loading.value = true;
+  try {
+    stats.value = await getGlobalStats();
+  } finally {
+    loading.value = false;
+  }
+}
+
+load();
 </script>
 
 <style scoped></style>

--- a/src/client/src/views/admin/ModelDetail.vue
+++ b/src/client/src/views/admin/ModelDetail.vue
@@ -1,12 +1,47 @@
 <template>
   <div>
     <h1 class="text-xl mb-2">Model Detail</h1>
-    <p>Details for model {{ $route.params.id }}</p>
+    <div v-if="loading">Loading...</div>
+    <div v-else class="text-sm space-y-1">
+      <div><strong>ID:</strong> {{ model?.modelId }}</div>
+      <div><strong>Last Modified:</strong> {{ model?.lastModified }}</div>
+      <div><strong>Downloads:</strong> {{ model?.downloads }}</div>
+      <div><strong>SHA:</strong> {{ model?.sha }}</div>
+      <div>
+        <strong>Tags:</strong>
+        <span v-for="t in model?.tags" :key="t" class="mr-1">{{ t }}</span>
+      </div>
+      <div>
+        <strong>Files:</strong>
+        <ul class="list-disc list-inside">
+          <li v-for="f in model?.files" :key="f">{{ f }}</li>
+        </ul>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Placeholder for model detail view.
+import { ref } from "vue";
+import { useRoute } from "vue-router";
+import { getModelById, type ModelDetail } from "../../services/models";
+
+const route = useRoute();
+const loading = ref(true);
+const model = ref<ModelDetail | null>(null);
+
+async function load() {
+  loading.value = true;
+  try {
+    model.value = await getModelById(route.params.id as string);
+  } catch {
+    model.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+load();
 </script>
 
 <style scoped></style>

--- a/src/client/src/views/admin/ModelList.vue
+++ b/src/client/src/views/admin/ModelList.vue
@@ -37,7 +37,12 @@
           class="border-b border-gray-800"
         >
           <td class="py-1">
-            <ModelCard>{{ m.modelId }}</ModelCard>
+            <RouterLink
+              :to="`/admin/models/${m.modelId}`"
+              class="text-blue-400 hover:underline"
+            >
+              <ModelCard>{{ m.modelId }}</ModelCard>
+            </RouterLink>
           </td>
           <td class="py-1">{{ m.lastModified }}</td>
           <td class="py-1">{{ m.downloads }}</td>
@@ -67,6 +72,7 @@
 <script setup lang="ts">
 // View for listing all models. Formerly `ManageModels.vue`.
 import { ref, computed } from "vue";
+import { RouterLink } from "vue-router";
 import {
   getAllModels,
   enableModel,

--- a/src/client/src/views/admin/ModelStats.vue
+++ b/src/client/src/views/admin/ModelStats.vue
@@ -1,12 +1,35 @@
 <template>
   <div>
     <h1 class="text-xl mb-2">Model Stats</h1>
-    <p>Stats for model {{ $route.params.id }}</p>
+    <div v-if="loading">Loading...</div>
+    <div v-else class="text-sm space-y-1">
+      <div><strong>ID:</strong> {{ stats?.modelId }}</div>
+      <div><strong>Downloads:</strong> {{ stats?.downloads }}</div>
+      <div><strong>Last Modified:</strong> {{ stats?.lastModified }}</div>
+      <div><strong>SHA:</strong> {{ stats?.sha }}</div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Placeholder for model stats view.
+import { ref } from "vue";
+import { useRoute } from "vue-router";
+import { getModelStats, type ModelDetail } from "../../services/models";
+
+const route = useRoute();
+const loading = ref(true);
+const stats = ref<ModelDetail | null>(null);
+
+async function load() {
+  loading.value = true;
+  try {
+    stats.value = await getModelStats(route.params.id as string);
+  } finally {
+    loading.value = false;
+  }
+}
+
+load();
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary
- add admin model docs
- implement `GetModelDetail` and `GetGlobalStats`
- extend model API handler for detail/stats endpoints
- enhance admin Vue pages to show model data

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68726c2e6cd48322b142162461c8038a