### PR TITLE
Add model caching and refresh

### DIFF
--- a/src/client/src/services/models.ts
+++ b/src/client/src/services/models.ts
@@ -54,6 +54,14 @@ export async function syncModels(): Promise<void> {
   if (!res.ok) throw new Error("Failed to sync models");
 }
 
+export async function refreshModels(pipeline: string): Promise<void> {
+  const res = await fetch(
+    `${BASE}/refresh?pipeline=${encodeURIComponent(pipeline)}`,
+    { method: "POST" },
+  );
+  if (!res.ok) throw new Error("Failed to refresh models");
+}
+
 export async function enableModel(id: string): Promise<void> {
   const res = await fetch(`${BASE}/${encodeURIComponent(id)}/enable`, {
     method: "POST",

--- a/src/client/src/views/admin/ModelList.vue
+++ b/src/client/src/views/admin/ModelList.vue
@@ -12,14 +12,20 @@
         </button>
       </nav>
     </div>
-    <div class="my-2">
-      <input
-        v-model="search"
-        type="text"
-        placeholder="Search models"
-        class="w-full p-1 rounded bg-gray-800 border border-gray-700 text-sm"
-      />
-    </div>
+  <div class="my-2">
+    <input
+      v-model="search"
+      type="text"
+      placeholder="Search models"
+      class="w-full p-1 rounded bg-gray-800 border border-gray-700 text-sm"
+    />
+    <button
+      @click="refresh"
+      class="ml-2 text-sm text-blue-400 hover:underline"
+    >
+      Refresh
+    </button>
+  </div>
     <div v-if="loading" class="py-2">Loading...</div>
     <table v-else class="text-sm w-full border-collapse">
       <thead>
@@ -77,6 +83,7 @@ import {
   getAllModels,
   enableModel,
   downloadModel,
+  refreshModels,
   type Model,
 } from "../../services/models";
 import ModelCard from "../../components/model/ModelCard.vue";
@@ -107,6 +114,16 @@ async function load() {
     models.value = await getAllModels(selected.value);
   } catch {
     models.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function refresh() {
+  loading.value = true;
+  try {
+    await refreshModels(selected.value);
+    models.value = await getAllModels(selected.value);
   } finally {
     loading.value = false;
   }

--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -40,6 +40,7 @@ var serveCmd = &cobra.Command{
 		http.HandleFunc("/api/users", handlers2.WithAdmin(handlers2.UsersHandler))
 		http.HandleFunc("/api/models", handlers2.WithAdmin(handlers2.ModelsHandler))
 		http.HandleFunc("/api/models/", handlers2.WithAdmin(handlers2.ModelActionHandler))
+		http.HandleFunc("/api/models/refresh", handlers2.WithAdmin(handlers2.RefreshModelsHandler))
 		http.HandleFunc("/api/verify", handlers2.VerifyHandler)
 		http.HandleFunc("/api/reset/request", handlers2.ResetRequestHandler)
 		http.HandleFunc("/api/reset", handlers2.ResetPasswordHandler)

--- a/src/memory/memory.go
+++ b/src/memory/memory.go
@@ -76,6 +76,18 @@ func InitDB() (*sql.DB, error) {
 		db.Close()
 		return nil, err
 	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS model_cache (
+               id TEXT PRIMARY KEY,
+               pipeline TEXT,
+               last_modified TEXT,
+               downloads INTEGER,
+               tags TEXT,
+               sha TEXT,
+               files TEXT
+       );`); err != nil {
+		db.Close()
+		return nil, err
+	}
 	return db, nil
 }
 

--- a/src/memory/models.go
+++ b/src/memory/models.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"codex/src/models"
+	"database/sql"
+	"encoding/json"
+)
+
+// SaveModelList stores a slice of model metadata for a given pipeline.
+func SaveModelList(db *sql.DB, pipeline string, list []models.ModelInfo) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare(`INSERT OR REPLACE INTO model_cache(id,pipeline,last_modified,downloads,tags) VALUES(?,?,?,?,?)`)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, m := range list {
+		tags, _ := json.Marshal(m.Tags)
+		if _, err := stmt.Exec(m.ID, pipeline, m.LastModified, m.Downloads, string(tags)); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetModelList returns cached models for a pipeline if present.
+func GetModelList(db *sql.DB, pipeline string) ([]models.ModelInfo, error) {
+	rows, err := db.Query(`SELECT id,last_modified,downloads,tags FROM model_cache WHERE pipeline=?`, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []models.ModelInfo
+	for rows.Next() {
+		var id, lm, tagsStr string
+		var dl int
+		if err := rows.Scan(&id, &lm, &dl, &tagsStr); err != nil {
+			return nil, err
+		}
+		var tags []string
+		json.Unmarshal([]byte(tagsStr), &tags)
+		res = append(res, models.ModelInfo{ID: id, LastModified: lm, Downloads: dl, Tags: tags})
+	}
+	return res, rows.Err()
+}
+
+// SaveModelDetail stores detailed metadata for a single model.
+func SaveModelDetail(db *sql.DB, pipeline string, detail *models.ModelDetail) error {
+	tags, _ := json.Marshal(detail.Tags)
+	files, _ := json.Marshal(detail.Files)
+	_, err := db.Exec(`INSERT OR REPLACE INTO model_cache(id,pipeline,last_modified,downloads,tags,sha,files) VALUES(?,?,?,?,?,?,?)`,
+		detail.ID, pipeline, detail.LastModified, detail.Downloads, string(tags), detail.SHA, string(files))
+	return err
+}
+
+// GetModelDetail returns cached detail for the given model ID or nil if absent.
+func GetModelDetail(db *sql.DB, id string) (*models.ModelDetail, error) {
+	row := db.QueryRow(`SELECT pipeline,last_modified,downloads,tags,sha,files FROM model_cache WHERE id=?`, id)
+	var pipeline, lm, tagsStr, sha, filesStr string
+	var dl int
+	if err := row.Scan(&pipeline, &lm, &dl, &tagsStr, &sha, &filesStr); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var tags []string
+	var files []string
+	json.Unmarshal([]byte(tagsStr), &tags)
+	json.Unmarshal([]byte(filesStr), &files)
+	return &models.ModelDetail{
+		ModelInfo: models.ModelInfo{ID: id, LastModified: lm, Downloads: dl, Tags: tags},
+		SHA:       sha,
+		Files:     files,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- store HuggingFace model metadata in SQLite `model_cache`
- load cached models before fetching remote data
- add admin endpoint `/api/models/refresh` for redownloading metadata
- wire new route and add refresh button in the admin UI

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872830197e88322b21e9374c74919ed