### PR TITLE
Add detailed model metadata

### DIFF
--- a/src/memory/memory.go
+++ b/src/memory/memory.go
@@ -83,11 +83,36 @@ func InitDB() (*sql.DB, error) {
                downloads INTEGER,
                tags TEXT,
                sha TEXT,
-               files TEXT
+               files TEXT,
+               llama_compatible INTEGER DEFAULT 0,
+               model_type TEXT,
+               hidden_size INTEGER,
+               n_layer INTEGER,
+               num_attention_heads INTEGER,
+               quantized INTEGER DEFAULT 0,
+               gguf INTEGER DEFAULT 0,
+               safetensors INTEGER DEFAULT 0,
+               compatible_backends TEXT,
+               license TEXT,
+               model_card TEXT,
+               download_size INTEGER
        );`); err != nil {
 		db.Close()
 		return nil, err
 	}
+	// attempt to add columns for new metadata if the table existed without them
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN llama_compatible INTEGER DEFAULT 0`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN model_type TEXT`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN hidden_size INTEGER`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN n_layer INTEGER`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN num_attention_heads INTEGER`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN quantized INTEGER DEFAULT 0`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN gguf INTEGER DEFAULT 0`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN safetensors INTEGER DEFAULT 0`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN compatible_backends TEXT`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN license TEXT`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN model_card TEXT`)
+	db.Exec(`ALTER TABLE model_cache ADD COLUMN download_size INTEGER`)
 	return db, nil
 }
 

--- a/src/memory/models.go
+++ b/src/memory/models.go
@@ -58,6 +58,84 @@ func SaveModelDetail(db *sql.DB, pipeline string, detail *models.ModelDetail) er
 	return err
 }
 
+// SaveModelMetadata persists the enriched model information produced by
+// models.GetModelMetadata. Boolean values are stored as integers for SQLite
+// compatibility.
+func SaveModelMetadata(db *sql.DB, pipeline string, md *models.ModelMetadata) error {
+	tags, _ := json.Marshal(md.Tags)
+	files, _ := json.Marshal(md.Files)
+	backends, _ := json.Marshal(md.CompatibleBackends)
+	_, err := db.Exec(`INSERT OR REPLACE INTO model_cache(
+                id,pipeline,last_modified,downloads,tags,sha,files,
+                llama_compatible,model_type,hidden_size,n_layer,num_attention_heads,
+                quantized,gguf,safetensors,compatible_backends,license,model_card,download_size)
+                VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		md.ID, pipeline, md.LastModified, md.Downloads, string(tags), md.SHA, string(files),
+		boolToInt(md.LlamaCompatible), md.ModelType, md.HiddenSize, md.NLayer, md.NumAttentionHeads,
+		boolToInt(md.Quantized), boolToInt(md.GGUF), boolToInt(md.Safetensors), string(backends),
+		md.License, md.ModelCard, md.DownloadSize,
+	)
+	return err
+}
+
+// GetModelMetadata returns cached enriched detail for the given model ID if present.
+func GetModelMetadata(db *sql.DB, id string) (*models.ModelMetadata, error) {
+	row := db.QueryRow(`SELECT pipeline,last_modified,downloads,tags,sha,files,
+                llama_compatible,model_type,hidden_size,n_layer,num_attention_heads,
+                quantized,gguf,safetensors,compatible_backends,license,model_card,download_size
+                FROM model_cache WHERE id=?`, id)
+	var pipeline, lm, tagsStr, sha, filesStr string
+	var llama, quant, gguf, safe int
+	var modelType, license, card, backendsStr sql.NullString
+	var hidden, nl, heads sql.NullInt64
+	var dl int
+	var size sql.NullInt64
+	if err := row.Scan(&pipeline, &lm, &dl, &tagsStr, &sha, &filesStr,
+		&llama, &modelType, &hidden, &nl, &heads,
+		&quant, &gguf, &safe, &backendsStr, &license, &card, &size); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var tags []string
+	var files []string
+	var backends []string
+	json.Unmarshal([]byte(tagsStr), &tags)
+	json.Unmarshal([]byte(filesStr), &files)
+	if backendsStr.Valid {
+		json.Unmarshal([]byte(backendsStr.String), &backends)
+	}
+	md := &models.ModelMetadata{
+		ModelDetail: models.ModelDetail{
+			ModelInfo: models.ModelInfo{ID: id, LastModified: lm, Downloads: dl, Tags: tags},
+			SHA:       sha,
+			Files:     files,
+		},
+		LlamaCompatible:    llama == 1,
+		ModelType:          modelType.String,
+		HiddenSize:         int(hidden.Int64),
+		NLayer:             int(nl.Int64),
+		NumAttentionHeads:  int(heads.Int64),
+		Quantized:          quant == 1,
+		GGUF:               gguf == 1,
+		Safetensors:        safe == 1,
+		CompatibleBackends: backends,
+		License:            license.String,
+		ModelCard:          card.String,
+		DownloadSize:       size.Int64,
+	}
+	return md, nil
+}
+
+// boolToInt converts a boolean to 0 or 1 for SQLite storage.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // GetModelDetail returns cached detail for the given model ID or nil if absent.
 func GetModelDetail(db *sql.DB, id string) (*models.ModelDetail, error) {
 	row := db.QueryRow(`SELECT pipeline,last_modified,downloads,tags,sha,files FROM model_cache WHERE id=?`, id)


### PR DESCRIPTION
## Summary
- enrich model metadata with info from `config.json`
- check for LLaMA compatibility
- detect file types and backends from Hugging Face siblings list
- track model license and download size
- expand SQLite schema to store these fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68728a52a7d0832282c0e2677111fef9